### PR TITLE
corrected repo name to lowercase

### DIFF
--- a/docs/hosting/intro.md
+++ b/docs/hosting/intro.md
@@ -35,7 +35,7 @@ Firstly we need to include the Authentication Proxy as a service by adding the f
 
 ```yaml
 proxy:
-  image: ghcr.io/Ipmake/kocity-proxy
+  image: ghcr.io/ipmake/kocity-proxy
   container_name: koc-proxy
 
   environment:


### PR DESCRIPTION
Error response from daemon: invalid reference format: repository name must be lowercase